### PR TITLE
Fix entrance alignment to match world start marker rotation

### DIFF
--- a/Source/TestLevel/Generator/LocationRoom.h
+++ b/Source/TestLevel/Generator/LocationRoom.h
@@ -46,10 +46,11 @@ protected:
 	FRandomStream Rng;
 
 	// Geometry helpers
-	FVector2f GetHalfSize() const;
-	FVector SideOriginWorld(ERoomSide Side) const;
-	FVector SideDirection(ERoomSide Side) const;
-	FVector LocalOut(ERoomSide) const;
+        FVector2f GetHalfSize() const;
+        FVector SideOriginWorld(ERoomSide Side) const;
+        FVector SideDirection(ERoomSide Side) const;
+        FVector SideDirectionWorld(ERoomSide Side) const;
+        FVector LocalOut(ERoomSide) const;
 	bool IsInsideRoom(const FVector& P) const;
 	bool SatisfiesMinDist(const FVector& P, const TArray<FVector>& Points, float MinDist) const;
 


### PR DESCRIPTION
## Summary
- rotate side origins and directions by the room transform so entrance/exits line up with any world start marker orientation
- add a world-space helper for side directions and reuse it when placing walls and finish markers to respect rotation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb2e3a0f0832ab3218da597fd391e