### PR TITLE
Fix entrance alignment to match world start marker rotation

### DIFF
--- a/Source/TestLevel/Generator/LocationRoom.cpp
+++ b/Source/TestLevel/Generator/LocationRoom.cpp
@@ -51,19 +51,27 @@ FVector ALocationRoom::RoomLocalToWorld(const FVector& L) const
 
 FVector ALocationRoom::SideOriginWorld(ERoomSide Side) const
 {
-	const FVector2f H = GetHalfSize();
-	const FVector Center = GetRoomCenter();
+        const FVector2f H = GetHalfSize();
+        const FVector Center = GetRoomCenter();
+        const FQuat RoomQ = GetActorQuat();
+        const FVector LocalOffset = LocalOut(Side) * FVector(H.X, H.Y, 0.f);
 
-	return Center + LocalOut(Side) * FVector(H.X, H.Y, 0.f);
+        return Center + RoomQ.RotateVector(LocalOffset);
 }
 
 FVector ALocationRoom::SideDirection(ERoomSide Side) const
 {
-	if (Side == ERoomSide::North || Side == ERoomSide::South)
-	{
-		return FVector(1, 0, 0); // along X 
-	}
-	return FVector(0, 1, 0); // along Y
+        if (Side == ERoomSide::North || Side == ERoomSide::South)
+        {
+                return FVector(1, 0, 0); // along X
+        }
+        return FVector(0, 1, 0); // along Y
+}
+
+FVector ALocationRoom::SideDirectionWorld(ERoomSide Side) const
+{
+        const FQuat RoomQ = GetActorQuat();
+        return RoomQ.RotateVector(SideDirection(Side));
 }
 
 FVector ALocationRoom::LocalOut(ERoomSide Side) const
@@ -130,15 +138,15 @@ void ALocationRoom::Generate(const UWorldGenSettings* Settings, AWorldStartMarke
 	Entrance.HalfWidth = GenSettings->DoorwayHalfWidth;
 	Entrance.WorldTransform = GetActorTransform();
 
-	const FVector OutWS = RoomQ.RotateVector(LocalOut(Entrance.Side)).GetSafeNormal();
-	const FVector AlongWS = RoomQ.RotateVector(SideDirection(Entrance.Side)).GetSafeNormal();
+        const FVector OutWS = RoomQ.RotateVector(LocalOut(Entrance.Side)).GetSafeNormal();
+        const FVector AlongWS = SideDirectionWorld(Entrance.Side).GetSafeNormal();
 	const FVector2f H = GetHalfSize();
 	const float HalfSpanToSide = (Entrance.Side == ERoomSide::North || Entrance.Side == ERoomSide::South) ? H.Y : H.X;
 	RoomCenter = EntranceWorld - OutWS * HalfSpanToSide - AlongWS * Entrance.OffsetAlongSide;
 
 	// --- 3) Compute along-offset ON THAT SIDE (rotation-aware) ---
-	const FVector SideOriginNow = SideOriginWorld(EntranceSide);
-	const FVector AlongDir = SideDirection(EntranceSide);
+        const FVector SideOriginNow = SideOriginWorld(EntranceSide);
+        const FVector AlongDir = SideDirectionWorld(EntranceSide);
 
 	const float HalfSpan = (EntranceSide == ERoomSide::North || EntranceSide == ERoomSide::South)
 		? GenSettings->RoomSize.Width * 0.5f    // span along local X
@@ -213,14 +221,11 @@ void ALocationRoom::Generate(const UWorldGenSettings* Settings, AWorldStartMarke
 
 		D.HalfWidth = GenSettings->DoorwayHalfWidth;
 
-		FVector LocalOrigin = SideOriginWorld(D.Side);
-		FVector LocalAlong = SideDirection(D.Side);
+                const FVector DOriginWS = SideOriginWorld(D.Side);
+                const FVector DAlongWS = SideDirectionWorld(D.Side).GetSafeNormal();
+                const FVector CenterWS = DOriginWS + DAlongWS * D.OffsetAlongSide;
 
-		const FVector DOriginWS = Entrance.WorldTransform.TransformPosition(LocalOrigin);
-		const FVector DAlongWS = RoomQ.RotateVector(LocalAlong).GetSafeNormal();
-		const FVector CenterWS = DOriginWS + DAlongWS * D.OffsetAlongSide;
-
-		const FVector DOutWS = RoomQ.RotateVector(LocalOut(D.Side)).GetSafeNormal();
+                const FVector DOutWS = RoomQ.RotateVector(LocalOut(D.Side)).GetSafeNormal();
 		const FRotator RotWS = UKismetMathLibrary::MakeRotFromXZ(DOutWS, FVector::UpVector);
 		
 		D.WorldTransform = FTransform(RotWS, CenterWS);
@@ -288,11 +293,11 @@ void ALocationRoom::BuildWallsWithOpenings(const FDoorwaySpec& Entrance)
 					Openings.Add(E);
 			}
 
-			const FVector SideOrigin = SideOriginWorld(Side);
-			const FVector Along = SideDirection(Side);
+                        const FVector SideOrigin = SideOriginWorld(Side);
+                        const FVector Along = SideDirectionWorld(Side).GetSafeNormal();
 
-			// Rotation for all segments on this side is constant
-			const FQuat SegmentRot = Along.Rotation().Quaternion();
+                        // Rotation for all segments on this side is constant
+                        const FQuat SegmentRot = Along.Rotation().Quaternion();
 
 			// Fast path: no openings → add all segments
 			if (Openings.Num() == 0)
@@ -301,11 +306,11 @@ void ALocationRoom::BuildWallsWithOpenings(const FDoorwaySpec& Entrance)
 				{
 					const float CenterOff = -Span * 0.5f + (i + 0.5f) * Step;
 
-					FTransform T;
-					T.SetLocation(SideOrigin + Along * CenterOff);
-					T.SetRotation(SegmentRot);
-					T.SetScale3D(FVector(1, 1, 1));
-					WallISM->AddInstance(T);
+                                        FTransform T;
+                                        T.SetLocation(SideOrigin + Along * CenterOff);
+                                        T.SetRotation(SegmentRot);
+                                        T.SetScale3D(FVector(1, 1, 1));
+                                        WallISM->AddInstanceWorldSpace(T);
 				}
 				return;
 			}
@@ -326,11 +331,11 @@ void ALocationRoom::BuildWallsWithOpenings(const FDoorwaySpec& Entrance)
 				}
 				if (bCovered) continue;
 
-				FTransform T;
-				T.SetLocation(SideOrigin + Along * CenterOff);
-				T.SetRotation(SegmentRot);
-				T.SetScale3D(FVector(1, 1, 1));
-				WallISM->AddInstance(T);
+                                FTransform T;
+                                T.SetLocation(SideOrigin + Along * CenterOff);
+                                T.SetRotation(SegmentRot);
+                                T.SetScale3D(FVector(1, 1, 1));
+                                WallISM->AddInstanceWorldSpace(T);
 			}
 		};
 
@@ -361,8 +366,8 @@ void ALocationRoom::SpawnFinishMarkers(TArray<AWorldFinishMarker*>& OutMarkers)
 
 	for (const FDoorwaySpec& D : Exits)
 	{
-		const FVector Origin = SideOriginWorld(D.Side);
-		const FVector Along = SideDirection(D.Side);
+                const FVector Origin = SideOriginWorld(D.Side);
+                const FVector Along = SideDirectionWorld(D.Side);
 		const FVector P = Origin + Along * D.OffsetAlongSide;
 
 		if (AWorldFinishMarker* Marker = W->SpawnActor<AWorldFinishMarker>(AWorldFinishMarker::StaticClass(), D.WorldTransform))

--- a/Source/TestLevel/Generator/LocationRoom.h
+++ b/Source/TestLevel/Generator/LocationRoom.h
@@ -46,10 +46,11 @@ protected:
 	FRandomStream Rng;
 
 	// Geometry helpers
-	FVector2f GetHalfSize() const;
-	FVector SideOriginWorld(ERoomSide Side) const;
-	FVector SideDirection(ERoomSide Side) const;
-	FVector LocalOut(ERoomSide) const;
+        FVector2f GetHalfSize() const;
+        FVector SideOriginWorld(ERoomSide Side) const;
+        FVector SideDirection(ERoomSide Side) const;
+        FVector SideDirectionWorld(ERoomSide Side) const;
+        FVector LocalOut(ERoomSide) const;
 	bool IsInsideRoom(const FVector& P) const;
 	bool SatisfiesMinDist(const FVector& P, const TArray<FVector>& Points, float MinDist) const;
 


### PR DESCRIPTION
## Summary
- rotate side origins and directions by the room transform so entrance/exits line up with any world start marker orientation
- add a world-space helper for side directions and reuse it when placing walls and finish markers to respect rotation
- place wall segments using world-space transforms so openings stay aligned with their exit markers after rotation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb2e3a0f0832ab3218da597fd391e