### PR TITLE
Add road curvature control and keep monsters away from roads

### DIFF
--- a/Source/TestLevel/Generator/LocationRoom.h
+++ b/Source/TestLevel/Generator/LocationRoom.h
@@ -46,12 +46,14 @@ protected:
 	FRandomStream Rng;
 
 	// Geometry helpers
-	FVector2f GetHalfSize() const;
-	FVector SideOriginWorld(ERoomSide Side) const;
-	FVector SideDirection(ERoomSide Side) const;
-	FVector LocalOut(ERoomSide) const;
-	bool IsInsideRoom(const FVector& P) const;
-	bool SatisfiesMinDist(const FVector& P, const TArray<FVector>& Points, float MinDist) const;
+        FVector2f GetHalfSize() const;
+        FVector SideOriginWorld(ERoomSide Side) const;
+        FVector SideDirection(ERoomSide Side) const;
+        FVector SideDirectionWorld(ERoomSide Side) const;
+        FVector LocalOut(ERoomSide) const;
+        bool IsInsideRoom(const FVector& P) const;
+        bool SatisfiesMinDist(const FVector& P, const TArray<FVector>& Points, float MinDist) const;
+        float DistanceToRoads(const FVector& P) const;
 
 
 	// Steps
@@ -76,9 +78,12 @@ private:
 	UPROPERTY(Transient)
 	TArray<FVector> RoadPoint;
 
-	UPROPERTY(Transient)
-	TArray<AActor*> POIs;
+        UPROPERTY(Transient)
+        TArray<AActor*> POIs;
 
-	UPROPERTY(Transient)
-	FVector RoomCenter = FVector::ZeroVector;
+        UPROPERTY(Transient)
+        FVector RoomCenter = FVector::ZeroVector;
+
+        UPROPERTY(Transient)
+        ARoadSegment* RoadNetwork = nullptr;
 };

--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -36,26 +36,34 @@ protected:
 	void MaybeAddShortcuts(const TArray<FVector2f>& PtsLocal, const FVector2f& H, TArray<FIntPoint>& InOutEdges);
 
 	// Generate naturally-curved path points for the edge (A,B)
-	void MakeCurvedPath(const FVector& A, const FVector& B,
-		int32 MidCount,
-		float MaxPerp,
-		float NoiseJitter,
-		float TangentStrength,
-		FRandomStream& Rng,
-		TArray<FVector>& OutPoints);
+        void MakeCurvedPath(const FVector& A, const FVector& B,
+                int32 MidCount,
+                float MaxPerp,
+                float NoiseJitter,
+                float TangentStrength,
+                float BaselineCurvature,
+                FRandomStream& Rng,
+                TArray<FVector>& OutPoints);
 
-	// Compute per-edge offset scale so paths near walls wiggle less
-	float EdgeOffsetScale(const FVector2f& A_L, const FVector2f& B_L, const FVector2f& H);
+        // Compute per-edge offset scale so paths near walls wiggle less
+        float EdgeOffsetScale(const FVector2f& A_L, const FVector2f& B_L, const FVector2f& H);
 
-	UPROPERTY() 
-	TArray<class USplineMeshComponent*> MeshSegments;
+        UPROPERTY()
+        TArray<class USplineMeshComponent*> MeshSegments;
 
-	void ClearMeshes();
+        void ClearMeshes();
+
+public:
+        // Returns minimal planar distance (XY) from the cached road polylines.
+        float DistanceToRoads(const FVector& Point) const;
 
 private:
-	UPROPERTY()
-	const UWorldGenSettings* GenSettings = nullptr;
+        UPROPERTY()
+        const UWorldGenSettings* GenSettings = nullptr;
 
-	float ClearanceToRect(const FVector2f& P, const FVector2f& H);
+        UPROPERTY(Transient)
+        TArray<TArray<FVector>> BuiltPaths;
+
+        float ClearanceToRect(const FVector2f& P, const FVector2f& H);
 
 };

--- a/Source/TestLevel/Generator/WorldGenSettings.h
+++ b/Source/TestLevel/Generator/WorldGenSettings.h
@@ -51,14 +51,18 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
 	float RoadMaxPerpOffset = 600.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
-	float RoadNoiseJitter = 150.f;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
+        float RoadNoiseJitter = 150.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
-	float RoadTangentStrength = 800.f;
-	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
-	FVector2f RoadMargin = FVector2f(100.f, 100.f);
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
+        float RoadTangentStrength = 800.f;
+
+        // Adds a gentle baseline curvature to every road (scaled by path length).
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
+        float RoadBaselineCurvature = 0.05f;
+
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
+        FVector2f RoadMargin = FVector2f(100.f, 100.f);
 	
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
 	float RoadExitApproachOffset = 100.f;
@@ -95,11 +99,14 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
 	FIntRangeInclusive MonsterPackCountRange{ 1, 3 };
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
-	float MonsterMinDistanceFromPortals = 700.f;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
+        float MonsterMinDistanceFromPortals = 700.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
-	float MonsterMinDistanceFromPOI = 500.f;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
+        float MonsterMinDistanceFromPOI = 500.f;
+
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
+        float MonsterMinDistanceFromRoad = 400.f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Monsters")
 	TArray<FMonsterSpawn> MonsterTable;


### PR DESCRIPTION
## Summary
- add a configurable baseline curvature parameter so generated roads gently arc instead of staying perfectly straight
- cache the generated road polylines and expose a distance query that the room generator uses when sampling monster spawn points
- enforce a minimum distance between monsters and any road using the new world-gen setting while keeping previous spacing rules intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb2e3a0f0832ab3218da597fd391e