### PR TITLE
Add environment-aware room generation

### DIFF
--- a/Source/TestLevel/Generator/LocationRoom.h
+++ b/Source/TestLevel/Generator/LocationRoom.h
@@ -63,6 +63,7 @@ protected:
 	void BuildWallsWithOpenings(const FDoorwaySpec& Entrance);
 	void SpawnFinishMarkers(TArray<AWorldFinishMarker*>& OutMarkers);
 	void SpawnPOIs(const FVector& EntranceWorld, TArray<AActor*>& OutPOIs);
+	void SpawnEnvironment();
 	void SpawnMonsters(TArray<AActor*>& OutMonsters);
 	void SpawnRoads();
 
@@ -82,8 +83,21 @@ private:
         TArray<AActor*> POIs;
 
         UPROPERTY(Transient)
+        FVector EntranceLocation = FVector::ZeroVector;
+
+        UPROPERTY(Transient)
+        TArray<FEnvironmentObstacle> EnvironmentObstacles;
+
+        UPROPERTY(Transient)
+        TArray<UInstancedStaticMeshComponent*> EnvironmentComponents;
+
+        UPROPERTY(Transient)
         FVector RoomCenter = FVector::ZeroVector;
 
         UPROPERTY(Transient)
         ARoadSegment* RoadNetwork = nullptr;
+
+        bool CanPlaceEnvironmentAt(const FVector& Candidate, const FEnvironmentSpawnEntry& Entry, const TArray<FVector>& CorridorTargets) const;
+        bool KeepsCorridorsOpen(const FVector2D& Candidate, float Radius, const FEnvironmentSpawnEntry& Entry, const TArray<FVector>& CorridorTargets) const;
+        static float DistancePointToSegment2D(const FVector2D& P, const FVector2D& A, const FVector2D& B);
 };

--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -19,7 +19,7 @@ class TESTLEVEL_API ARoadSegment : public AActor
 public:
 	ARoadSegment();
 
-	void BuildNetwork(const TArray<FVector>& NodesWS, int32 ExitCount, const FVector2f& RoomHalfSize, const UWorldGenSettings* Settings, FRandomStream& Rng);
+	void BuildNetwork(const TArray<FVector>& NodesWS, int32 ExitCount, const FVector2f& RoomHalfSize, const UWorldGenSettings* Settings, FRandomStream& Rng, const TArray<FEnvironmentObstacle>& Obstacles);
 
 	void ClearNetwork();
 
@@ -48,6 +48,9 @@ protected:
         // Compute per-edge offset scale so paths near walls wiggle less
         float EdgeOffsetScale(const FVector2f& A_L, const FVector2f& B_L, const FVector2f& H);
 
+        FVector AdjustForObstacles(const FVector& Point) const;
+        FVector ClampToRoomBounds(const FVector& Point) const;
+
         UPROPERTY()
         TArray<class USplineMeshComponent*> MeshSegments;
 
@@ -62,6 +65,8 @@ private:
         const UWorldGenSettings* GenSettings = nullptr;
 
         TArray<TArray<FVector>> BuiltPaths;
+        TArray<FEnvironmentObstacle> CachedObstacles;
+        FVector2f CachedRoomHalfSize = FVector2f::ZeroVector;
 
         float ClearanceToRect(const FVector2f& P, const FVector2f& H);
 

--- a/Source/TestLevel/Generator/WorldGenSettings.h
+++ b/Source/TestLevel/Generator/WorldGenSettings.h
@@ -44,6 +44,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Meshes")
 	UStaticMesh* RoadSplineMesh = nullptr;
 
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Environment")
+	TArray<FEnvironmentSpawnEntry> EnvironmentMeshes;
+
 	// --- Roads ---
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Road")
 	int32 RoadMidpointCount = 2;

--- a/Source/TestLevel/Generator/WorldGenTypes.h
+++ b/Source/TestLevel/Generator/WorldGenTypes.h
@@ -81,6 +81,56 @@ struct FPOISpawn
 	float Weight = 1.f;
 };
 
+/** Static environment mesh spawn entry. */
+USTRUCT(BlueprintType)
+struct FEnvironmentSpawnEntry
+{
+	GENERATED_BODY();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UStaticMesh* Mesh = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	int32 MinCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	int32 MaxCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+	float Radius = 200.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+	float MinSpacing = 150.f;
+
+	// Keep some breathing room around entrance/exits/POIs so they stay reachable.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+	float ClearanceFromKeyPoints = 400.f;
+
+	// Corridor half-width that must remain unobstructed between entrance and every key point.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+	float CorridorHalfWidth = 250.f;
+
+	int32 ResolveCount(FRandomStream& Rng) const
+	{
+		const int32 Lo = FMath::Max(0, FMath::Min(MinCount, MaxCount));
+		const int32 Hi = FMath::Max(Lo, FMath::Max(MinCount, MaxCount));
+		return (Lo == Hi) ? Lo : Rng.RandRange(Lo, Hi);
+	}
+};
+
+/** Runtime obstacle description used by road/path planning. */
+USTRUCT(BlueprintType)
+struct FEnvironmentObstacle
+{
+	GENERATED_BODY();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FVector Location = FVector::ZeroVector;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float Radius = 0.f;
+};
+
 /** One doorway opening spec along a given side. */
 USTRUCT(BlueprintType)
 struct FDoorwaySpec


### PR DESCRIPTION
## Summary
- align the generated room with the start marker transform so the entrance reacts to marker rotation
- add configurable environment mesh spawns that keep corridors to key points open and cache obstacles for planning
- update road construction to account for environment obstacles and clamp paths inside the room bounds

## Testing
- not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68cfe42094a8832a8d495c6538f9cca2