### PR TITLE
Refine road network generation

### DIFF
--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -27,9 +27,9 @@ protected:
 	UPROPERTY(VisibleAnywhere)
 	USceneComponent* Root;
 
-	void BuildOnePath(const TArray<FVector>& PathPointsWS);
+        void BuildOnePath(const TArray<FVector>& PathPointsWS);
 
-	int32 FindNearestPointOnPath(const FVector& Point, const TArray<FVector>& Path);
+        bool FindNearestPointOnPath(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, float& OutDistSq) const;
 
 	// Utility used by BuildNetwork
 	void ComputeMST_Prim(const TArray<FVector2f>& PtsLocal, TArray<FIntPoint>& OutEdges);


### PR DESCRIPTION
## Summary
- rebuild the road network using the entry node, exit nodes, and POIs according to the new ordering
- ensure roads approach exits via offset approach points before snapping to portals and reuse the offset logic for every exit
- connect other exits and POIs by finding the nearest point on the current road network for the shortest attachments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff3a5a49c832a945e4bb815be6a5e