### PR TITLE
Refine road curvature and POI branching

### DIFF
--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -30,6 +30,8 @@ protected:
         void BuildOnePath(const TArray<FVector>& PathPointsWS);
 
         bool FindNearestPointOnPath(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, float& OutDistSq) const;
+        bool FindNearestPointOnPathDetailed(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, FVector& OutTangent,
+                float& OutDistSq, int32* OutSegmentIdx = nullptr, float* OutSegmentT = nullptr) const;
 
 	// Utility used by BuildNetwork
 	void ComputeMST_Prim(const TArray<FVector2f>& PtsLocal, TArray<FIntPoint>& OutEdges);


### PR DESCRIPTION
## Summary
- blend baseline curvature with wave noise when generating midpoints so splines follow smoother, more natural arcs
- expose a helper that returns the nearest path point plus tangent information for reuse by branching logic
- adjust exit and POI connections to use tangents, offset branch starts, and avoid sharp angles when connecting to the main road

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cff6295e98832ab0730fc5ea63f8af