### PR TITLE
Fix POI road paths and reset generated content

### DIFF
--- a/Source/TestLevel/Generator/LocationRoom.h
+++ b/Source/TestLevel/Generator/LocationRoom.h
@@ -64,29 +64,38 @@ protected:
 	void SpawnFinishMarkers(TArray<AWorldFinishMarker*>& OutMarkers);
 	void SpawnPOIs(const FVector& EntranceWorld, TArray<AActor*>& OutPOIs);
 	void SpawnEnvironment();
-	void SpawnMonsters(TArray<AActor*>& OutMonsters);
-	void SpawnRoads();
+        void SpawnMonsters(TArray<AActor*>& OutMonsters);
+        void SpawnRoads();
 
-	FORCEINLINE FVector GetRoomCenter() const;
-	FORCEINLINE FTransform GetRoomTransform() const;
-	FORCEINLINE FVector WorldToRoomLocal(const FVector& P) const;
-	FORCEINLINE FVector RoomLocalToWorld(const FVector& L) const;
+        FORCEINLINE FVector GetRoomCenter() const;
+        FORCEINLINE FTransform GetRoomTransform() const;
+        FORCEINLINE FVector WorldToRoomLocal(const FVector& P) const;
+        FORCEINLINE FVector RoomLocalToWorld(const FVector& L) const;
+
+        void CleanupGeneratedContent();
+        void DestroyEnvironment();
 
 private:
-	UPROPERTY(Transient)
-	TArray<FDoorwaySpec> Exits;
+        UPROPERTY(Transient)
+        TArray<FDoorwaySpec> Exits;
 
 	UPROPERTY(Transient)
 	TArray<FVector> RoadPoint;
 
-	UPROPERTY(Transient)
-	TArray<AActor*> POIs;
+        UPROPERTY(Transient)
+        TArray<AActor*> POIs;
 
-	UPROPERTY(Transient)
-	FVector EntranceLocation = FVector::ZeroVector;
+        UPROPERTY(Transient)
+        TArray<AActor*> SpawnedMonsters;
 
-	UPROPERTY(Transient)
-	TArray<FEnvironmentObstacle> EnvironmentObstacles;
+        UPROPERTY(Transient)
+        TArray<AWorldFinishMarker*> FinishMarkers;
+
+        UPROPERTY(Transient)
+        FVector EntranceLocation = FVector::ZeroVector;
+
+        UPROPERTY(Transient)
+        TArray<FEnvironmentObstacle> EnvironmentObstacles;
 
 	UPROPERTY(Transient)
 	TArray<UInstancedStaticMeshComponent*> EnvironmentComponents;

--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -33,29 +33,19 @@ protected:
         bool FindNearestPointOnPathDetailed(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, FVector& OutTangent,
                 float& OutDistSq, int32* OutSegmentIdx = nullptr, float* OutSegmentT = nullptr) const;
 
-	// Utility used by BuildNetwork
-	void ComputeMST_Prim(const TArray<FVector2f>& PtsLocal, TArray<FIntPoint>& OutEdges);
-	void MaybeAddShortcuts(const TArray<FVector2f>& PtsLocal, const FVector2f& H, TArray<FIntPoint>& InOutEdges);
+        // Utility used by BuildNetwork
+        void ComputeMST_Prim(const TArray<FVector2f>& PtsLocal, TArray<FIntPoint>& OutEdges);
+        void MaybeAddShortcuts(const TArray<FVector2f>& PtsLocal, const FVector2f& H, TArray<FIntPoint>& InOutEdges);
 
-	// Generate naturally-curved path points for the edge (A,B)
-        void MakeCurvedPath(const FVector& A, const FVector& B,
-                int32 MidCount,
-                float MaxPerp,
-                float NoiseJitter,
-                float TangentStrength,
-                float BaselineCurvature,
-                FRandomStream& Rng,
-                TArray<FVector>& OutPoints);
+        void BuildMainPath(const FVector& Start, const FVector& End, FRandomStream& Rng, TArray<FVector>& OutPoints);
+        void BuildBranchPath(const FVector& StartPoint, const FVector& StartTangent, const FVector& Target, FRandomStream& Rng, TArray<FVector>& OutPoints);
 
-        void BuildPOIBranchPath(const FVector& ConnectionPoint,
-                const FVector& ConnectionTangent,
-                const FVector& POILocation,
-                float ScalePOI,
-                FRandomStream& Rng,
-                TArray<FVector>& OutPoints);
-
-        FVector EvaluateHermite(const FVector& P0, const FVector& T0, const FVector& P1, const FVector& T1, float T) const;
-        FVector ClampBranchDeviation(const FVector& ConnectionPoint, const FVector& Forward, float MaxDistance, const FVector& Candidate) const;
+        void ResolveDetours(TArray<FVector>& Points, FRandomStream& Rng) const;
+        bool InsertDetours(TArray<FVector>& Points, FRandomStream& Rng) const;
+        bool SegmentBlockedByAny(const FVector& A, const FVector& B, const FEnvironmentObstacle*& OutObstacle, float& OutHitParam) const;
+        FVector MakeDetourPoint(const FVector& A, const FVector& B, const FEnvironmentObstacle& Obstacle, float SegmentParam, FRandomStream& Rng) const;
+        void RelaxPolyline(TArray<FVector>& Points) const;
+        void RemoveRedundantPoints(TArray<FVector>& Points) const;
 
         // Compute per-edge offset scale so paths near walls wiggle less
         float EdgeOffsetScale(const FVector2f& A_L, const FVector2f& B_L, const FVector2f& H);

--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -47,6 +47,16 @@ protected:
                 FRandomStream& Rng,
                 TArray<FVector>& OutPoints);
 
+        void BuildPOIBranchPath(const FVector& ConnectionPoint,
+                const FVector& ConnectionTangent,
+                const FVector& POILocation,
+                float ScalePOI,
+                FRandomStream& Rng,
+                TArray<FVector>& OutPoints);
+
+        FVector EvaluateHermite(const FVector& P0, const FVector& T0, const FVector& P1, const FVector& T1, float T) const;
+        FVector ClampBranchDeviation(const FVector& ConnectionPoint, const FVector& Forward, float MaxDistance, const FVector& Candidate) const;
+
         // Compute per-edge offset scale so paths near walls wiggle less
         float EdgeOffsetScale(const FVector2f& A_L, const FVector2f& B_L, const FVector2f& H);
 

--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -38,7 +38,8 @@ protected:
         void MaybeAddShortcuts(const TArray<FVector2f>& PtsLocal, const FVector2f& H, TArray<FIntPoint>& InOutEdges);
 
         void BuildMainPath(const FVector& Start, const FVector& End, FRandomStream& Rng, TArray<FVector>& OutPoints);
-        void BuildBranchPath(const FVector& StartPoint, const FVector& StartTangent, const FVector& Target, FRandomStream& Rng, TArray<FVector>& OutPoints);
+        void BuildBranchPath(const FVector& StartPoint, const FVector& Target, FRandomStream& Rng, TArray<FVector>& OutPoints);
+        void BuildOrganicPath(const FVector& Start, const FVector& End, FRandomStream& Rng, float DeviationRatio, int32 MinAnchorCount, TArray<FVector>& OutPoints);
 
         void ResolveDetours(TArray<FVector>& Points, FRandomStream& Rng) const;
         bool InsertDetours(TArray<FVector>& Points, FRandomStream& Rng) const;
@@ -68,8 +69,10 @@ private:
 
         TArray<TArray<FVector>> BuiltPaths;
         TArray<FEnvironmentObstacle> CachedObstacles;
+        TArray<FVector> CachedSplineSamples;
         FVector2f CachedRoomHalfSize = FVector2f::ZeroVector;
 
         float ClearanceToRect(const FVector2f& P, const FVector2f& H);
+        bool FindNearestSplineSample(const FVector& Point, FVector& OutPoint, float* OutDistSq = nullptr) const;
 
 };


### PR DESCRIPTION
## Summary
- add reusable cleanup hooks to `ALocationRoom` so every generation removes old finish markers, POIs, monsters, environment instances and road actors
- switch POI storage to class members and clear them when regenerating a location before spawning fresh content
- rework POI branch creation in `ARoadSegment` to clamp approach distance, add mild lateral offsets, and avoid sharp detours when connecting roads to nearby POIs

## Testing
- not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68d016316904832aaf6c6c7944ff4743