### PR TITLE
Rework road generation algorithm

### DIFF
--- a/Source/TestLevel/Generator/RoadSegment.h
+++ b/Source/TestLevel/Generator/RoadSegment.h
@@ -27,7 +27,7 @@ protected:
 	UPROPERTY(VisibleAnywhere)
 	USceneComponent* Root;
 
-        void BuildOnePath(const TArray<FVector>& PathPointsWS);
+        void BuildOnePath(const TArray<FVector>& PathPointsWS, TArray<FVector>* OutSampledPoints = nullptr);
 
         bool FindNearestPointOnPath(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, float& OutDistSq) const;
         bool FindNearestPointOnPathDetailed(const FVector& Point, const TArray<FVector>& Path, FVector& OutPoint, FVector& OutTangent,
@@ -57,6 +57,9 @@ protected:
         TArray<class USplineMeshComponent*> MeshSegments;
 
         void ClearMeshes();
+
+        // Cached dense points sampled from generated spline paths (world space).
+        TArray<FVector> CachedSplineSamples;
 
 public:
         // Returns minimal planar distance (XY) from the cached road polylines.


### PR DESCRIPTION
## Summary
- store dense spline samples when building spline meshes so future branches can snap to existing roads
- rework the road-connection logic to sequentially link the farthest exit, remaining exits, and POIs using nearest sampled points
- add subtle Perlin-based offsets when generating curved paths to keep roads looking natural

## Testing
- not run (Unreal build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d04a136f08832ab437dd72b78bb712